### PR TITLE
Add docs assets directory with placeholder logo

### DIFF
--- a/docs/assets/logo-placeholder.svg
+++ b/docs/assets/logo-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48" width="160" height="48">
+  <rect width="160" height="48" fill="#d9d9d9"/>
+  <text x="80" y="32" font-size="20" text-anchor="middle" fill="#333" font-family="Arial, sans-serif">LOGO</text>
+</svg>


### PR DESCRIPTION
## Summary
- create `docs/assets` directory
- add `logo-placeholder.svg` as a basic placeholder logo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444e7c6de08325b1d0af39b0a545cd