### PR TITLE
Send contact form data through n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ pip install -r requirements.txt
 pytest
 ```
 
+## ✉️ Envío del formulario a Google Sheets con n8n
+
+Para registrar las consultas del formulario en una hoja de cálculo, crea un flujo en n8n con un nodo **Webhook** y otro de **Google Sheets**. Usa la URL pública generada por el Webhook como valor de la constante `n8nWebhookURL` en `docs/scripts.js`.
+
 ---
 
 ## 💬 Retroalimentación con SiteDots

--- a/docs/contacto.html
+++ b/docs/contacto.html
@@ -45,7 +45,7 @@
       <!-- ====== FORMULARIO SIMPLE (PLACEHOLDER) ====== -->
       <section id="form-contacto" class="contact-form">
         <h2>Envíame un mensaje</h2>
-        <!-- Placeholder form — acción real pendiente de configuración backend/externo -->
+        <!-- Formulario conectado a un script de envío -->
         <form action="#" method="post">
           <label>Nombre
             <input type="text" name="nombre" placeholder="Tu nombre" required />
@@ -58,7 +58,7 @@
           </label>
           <button type="submit" class="cta-button">Enviar</button>
         </form>
-        <p class="form-note">*Formulario a modo de ejemplo. Configura el backend o servicio de correo antes de uso.</p>
+        <p class="form-note">*Los datos se registran en Google Sheets a través de un flujo configurado en n8n.</p>
       </section>
 
       <!-- ====== MAPA (PLACEHOLDER) ====== -->
@@ -71,6 +71,7 @@
     <footer>
       <p>&copy; 2025 Roger Arquitecto. Todos los derechos reservados.</p>
     </footer>
-  </div>
+</div>
+<script src="scripts.js"></script>
 </body>
 </html>

--- a/docs/scripts.js
+++ b/docs/scripts.js
@@ -1,2 +1,29 @@
 // scripts.js para sitio_web_roger
-// Puedes agregar aquí la lógica JS necesaria para el sitio
+// Lógica básica para enviar el formulario de contacto utilizando fetch
+
+document.addEventListener('DOMContentLoaded', () => {
+  const formSection = document.querySelector('#form-contacto form');
+  if (!formSection) return;
+
+  // Reemplaza la URL con la de tu webhook de n8n
+  const n8nWebhookURL = 'YOUR_N8N_WEBHOOK_URL';
+
+  formSection.addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const formData = new FormData(formSection);
+
+    try {
+      await fetch(n8nWebhookURL, {
+        method: 'POST',
+        body: formData,
+        mode: 'no-cors',
+      });
+
+      formSection.reset();
+      alert('¡Mensaje enviado exitosamente!');
+    } catch (error) {
+      alert('No se pudo enviar el mensaje. Por favor, inténtalo más tarde.');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- wire contact form submission to an n8n webhook
- update contact page note about n8n workflow
- document how to configure the webhook URL

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459f34fbdc8325a62478635cc5375d