### PR TITLE
Improve responsive styles

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -27,6 +27,11 @@ body {
   line-height: 1.6;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;
@@ -361,4 +366,38 @@ footer {
   h2 {
     font-size: 1.5rem;
   }
+  .container {
+    padding: var(--spacing-unit);
+  }
+  nav.main-nav ul {
+    flex-direction: column;
+    gap: var(--spacing-unit);
+  }
+  .contact-form form,
+  .service-list,
+  .grid-preview,
+  .grid-gallery {
+    grid-template-columns: 1fr !important;
+  }
+  .cta-button {
+    width: 100%;
+    text-align: center;
+  }
+  .avatar {
+    width: 180px;
+    height: 180px;
+  }
+  #chatbot-window {
+    width: 90vw;
+    right: 5vw;
+  }
+  .contact-form button,
+  form button {
+    font-size: 1rem;
+    padding: var(--spacing-unit);
+  }
+}
+
+body {
+  overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary
- refine mobile layout with additional rules for screens under 600px
- ensure images are responsive
- prevent horizontal overflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dbe90ec88325aae0cb74c994c69a