### PR TITLE
Add n8n docker-compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copie este archivo a `.env` y reemplace el valor con su token de Ngrok
+NGROK_AUTHTOKEN=tu_token_aqui

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ pytest
 
 Para registrar las consultas del formulario en una hoja de cálculo, crea un flujo en n8n con un nodo **Webhook** y otro de **Google Sheets**. Usa la URL pública generada por el Webhook como valor de la constante `n8nWebhookURL` en `docs/scripts.js`.
 
+### Docker-compose rápido para n8n
+
+El repositorio incluye un `docker-compose.yml` para levantar n8n junto con un
+túnel de Ngrok. Sigue estos pasos:
+
+1. Copia `.env.example` a `.env` y coloca tu `NGROK_AUTHTOKEN`.
+2. Ejecuta `docker compose up -d` para iniciar los contenedores.
+3. Abre la UI local en [http://localhost:5678](http://localhost:5678) o la URL
+   pública mostrada por Ngrok.
+
 ---
 
 ## 💬 Retroalimentación con SiteDots

--- a/assistant_context.json
+++ b/assistant_context.json
@@ -50,7 +50,6 @@
     }
   },
   "pendingTasks": [
-    "Configurar webhook n8n en docs/scripts.js",
     "Reemplazar imágenes de placeholder",
     "Completar contenido final",
     "Integrar chatbot con backend real",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+  n8n:
+    image: n8nio/n8n:1.37.2
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - TZ=America/Costa_Rica
+      - WEBHOOK_URL=https://humane-asp-smart.ngrok-free.app
+      - N8N_HOST=0.0.0.0
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+    volumes:
+      - ./n8n_data:/home/node/.n8n
+
+  ngrok:
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    command: >
+      http n8n:5678
+      --domain=humane-asp-smart.ngrok-free.app
+    depends_on:
+      - n8n
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}

--- a/docs/scripts.js
+++ b/docs/scripts.js
@@ -5,8 +5,9 @@
 const formSection = document.querySelector('#form-contacto form');
 if (formSection) {
 
-  // Reemplaza la URL con la de tu webhook de n8n
-  const n8nWebhookURL = 'YOUR_N8N_WEBHOOK_URL';
+  // URL definitiva del webhook generado por n8n + Ngrok
+  const n8nWebhookURL =
+    'https://humane-asp-smart.ngrok-free.app/webhook/roger-contacto';
 
   formSection.addEventListener('submit', async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- provide a docker-compose.yml to run n8n and ngrok
- add env example for ngrok token
- configure scripts.js with the public webhook URL
- mark webhook setup as complete in assistant context
- document docker-compose usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462b2c681c8325acf2b8b04396eca1